### PR TITLE
Fixed bug - 0793485 - 	BFA: Rename the trigger step for FortiSIEM pla…

### DIFF
--- a/playbooks/04 - Use Cases - Brute Force Attack/Investigate Brute Force Attempt (FortiSIEM).json
+++ b/playbooks/04 - Use Cases - Brute Force Attack/Investigate Brute Force Attempt (FortiSIEM).json
@@ -270,7 +270,7 @@
             "description": null,
             "arguments": {
                 "route": "1f292ab1-722b-4e76-aa10-c3922c590c72",
-                "title": "Investigate Brute Force",
+                "title": "Investigate Brute Force (FortiSIEM)",
                 "resources": [
                     "alerts"
                 ],

--- a/playbooks/04 - Use Cases - Brute Force Attack/collection.metadata.json
+++ b/playbooks/04 - Use Cases - Brute Force Attack/collection.metadata.json
@@ -1,7 +1,7 @@
 {
     "@context": "\/api\/3\/contexts\/WorkflowCollection",
     "@type": "WorkflowCollection",
-    "name": "04 - Use Cases - Brute Force Attack",
+    "name": "02 - Use Case - Brute Force Attack",
     "description": null,
     "visible": true,
     "image": null,


### PR DESCRIPTION


1.Fixed bug - 0793485 - 	BFA: Rename the trigger step for FortiSIEM playbook
2.Changed the collection name as per the new naming convention