### PR TITLE
Bugfixes

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "bruteForceAttackResponse",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "type": "solutionpack",
     "local": true,
     "label": "Brute Force Attack Response",

--- a/records/scenario/scenario0001.json
+++ b/records/scenario/scenario0001.json
@@ -11,7 +11,7 @@
                     "type": "executePlaybook",
                     "playbookIRI": "\/api\/3\/workflows\/77c44e01-4289-483b-9924-e2363aafe95e",
                     "preCreateMessage": "Creating demo record for Brute force Attempt captured in FortiSIEM ",
-                    "postCreateMessage": "",
+                    "postCreateMessage": "Demo alert record has been created for Brute force Attempt captured in FortiSIEM",
                     "waitTimeforNextStep": "0"
                 }
             ]
@@ -54,7 +54,7 @@
                         "destinationPort": "443"
                     },
                     "preCreateMessage": "Create Repeated Login Failure Alert",
-                    "postCreateMessage": "none",
+                    "postCreateMessage": "Demo alerts for Repeated Login Failure has been created.",
                     "waitTimeforNextStep": "5"
                 }
             ]


### PR DESCRIPTION
Unit Test Cases

Bugfix #0804871

- Added postCreateMessage in scenarios "Brute Force Attempt (FortiSIEM)" and "Brute Force Attempt"
- Validated that postCreateMessage is being added as a comment for scenario 'Brute Force Attempt' 
    > However, it is not getting added for scenario "Brute Force Attempt (FortiSIEM)" due to a bug in `Run Scenario - Create Alerts` playbook in SOC Simulation SP