### PR TITLE
Initial Commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Release Information
 
-* **Version**:  1.1.0
+* **Version**:  1.2.0
 * **Certified**: Yes
 * **Publisher**: Fortinet
 * **Compatible Version**: FortiSOAR v7.2.0 and above

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "bruteForceAttackResponse",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "type": "solutionpack",
     "local": true,
     "label": "Brute Force Attack Response",
@@ -24,7 +24,7 @@
     "publisher": "Fortinet",
     "certified": "true",
     "description": "Investigates login failures and also identifies other impacted assets that have been victims of the brute force attempts from a particular source of attack.\nFew important integrations used in the solution pack are VirusTotal, Microsoft Active Directory and Splunk.",
-    "help": "https://github.com/fortinet-fortisoar/solution-pack-brute-force-attack-response/blob/release/1.1.0/README.md",
+    "help": "https://github.com/fortinet-fortisoar/solution-pack-brute-force-attack-response/blob/release/1.2.0/README.md",
     "category": [
         "Authentication"
     ],

--- a/playbooks/02 - Use Case - Brute Force Attack/Investigate Brute Force Attempt (FortiSIEM).json
+++ b/playbooks/02 - Use Case - Brute Force Attack/Investigate Brute Force Attempt (FortiSIEM).json
@@ -406,6 +406,8 @@
                 },
                 "apply_async": false,
                 "step_variables": [],
+                "pass_parent_env": false,
+                "pass_input_record": true,
                 "workflowReference": "\/api\/3\/workflows\/79ebfed2-86ee-404d-b69c-02a448e1144d"
             },
             "status": null,

--- a/playbooks/02 - Use Case - Brute Force Attack/Scenario - FortiSIEM (Brute Force Attack) Alert.json
+++ b/playbooks/02 - Use Case - Brute Force Attack/Scenario - FortiSIEM (Brute Force Attack) Alert.json
@@ -1,10 +1,10 @@
 {
     "@type": "Workflow",
     "triggerLimit": null,
-    "name": "Generate > FortiSIEM (Brute Force Attack)",
+    "name": "Scenario - FortiSIEM (Brute Force Attack) Alert",
     "aliasName": null,
     "tag": null,
-    "description": "Playbook will generate a demo record - Brute Force Attack",
+    "description": "Generates a demo alert for Brute Force Attack from FortiSIEM.",
     "isActive": true,
     "debug": false,
     "singleRecordExecution": false,
@@ -180,5 +180,7 @@
     "owners": [],
     "isPrivate": false,
     "deletedAt": null,
-    "recordTags": []
+    "recordTags": [
+        "Scenario"
+    ]
 }

--- a/playbooks/tags.json
+++ b/playbooks/tags.json
@@ -1,3 +1,4 @@
 [
-    "ManualAction"
+    "ManualAction",
+    "Scenario"
 ]


### PR DESCRIPTION
> Updated SP version to V1.2.0 in README.md and info.json

> Mantis#0901913
- Validated that scenario playbook "Generate > FortiSIEM (Brute Force Attack)" has been renamed to "Scenario - FortiSIEM (Brute Force Attack) Alert"
- Validated that the `Scenario` tag is added to the playbook

> Mantis#0900709
Updated `Investigate Brute Force Attempt (FortiSIEM)` playbook
- Validated that the value of param `Parent Data Reference` set to "Input record Only" in the `Block Indicator` step
- Validated that the playbook is no longer failing after this change