### PR TITLE
1285281 changed source condition in FortiSIEM BFA playbook

### DIFF
--- a/playbooks/02 - Use Case - Brute Force Attack/Investigate Brute Force Attempt (FortiSIEM).json
+++ b/playbooks/02 - Use Case - Brute Force Attack/Investigate Brute Force Attempt (FortiSIEM).json
@@ -511,9 +511,9 @@
                             {
                                 "type": "primitive",
                                 "field": "source",
-                                "value": "FortiSIEM",
-                                "operator": "eq",
-                                "_operator": "eq"
+                                "value": "%FortiSIEM%",
+                                "operator": "like",
+                                "_operator": "like"
                             }
                         ]
                     }


### PR DESCRIPTION
1285281 | Investigate Brute Force Attempt:Playbooks Set to Inactive State – Not Visible in Execute Tab

Description:
- Playbook [Investigate Brute Force Attempt (FortiSIEM)] contains condition [source == FortiSIEM]
- As our FortiSIEM ingested event has source as 'Fortinet FortiSIEM' , this playbook was not getting displayed in trigger/execute list
- Changed condition to source contains 'FortiSIEM'


Impact:
Playbook [Investigate Brute Force Attempt (FortiSIEM)] is now visible in execute list
<img width="822" height="249" alt="image" src="https://github.com/user-attachments/assets/ae488769-f045-41af-86a3-75cc68943a57" />

